### PR TITLE
Resolved issue with SASS-Loader

### DIFF
--- a/css/skelet.css
+++ b/css/skelet.css
@@ -455,11 +455,11 @@ pre > code { display: block; padding: calc(var(--boxPadding) * 1); white-space: 
 @media (max-width: 600px) { .large-only, .only-large  { display:none!important } }
 @media (min-width: 601px) { .small-only, .only-small  { display:none!important } }
 
-.no-scrollbars { scrollbar-width: none; -ms-overflow-style: none; -moz-scrollbars-none; }
+.no-scrollbars { scrollbar-width: none; -ms-overflow-style: none;  }
 .no-scrollbars::-webkit-scrollbar { display:none }
-@media (max-width: 600px) { .no-scrollbars-s { scrollbar-width: none; -ms-overflow-style: none; -moz-scrollbars-none; } .no-scrollbars-s::-webkit-scrollbar { display: none; } }
-@media (min-width: 1024px) { .no-scrollbars-m { scrollbar-width: none; -ms-overflow-style: none; -moz-scrollbars-none; } .no-scrollbars-m::-webkit-scrollbar { display: none; } }
-@media (min-width: 1599px) { .no-scrollbars-l { scrollbar-width: none; -ms-overflow-style: none; -moz-scrollbars-none; } .no-scrollbars-l::-webkit-scrollbar { display: none; } }
+@media (max-width: 600px) { .no-scrollbars-s { scrollbar-width: none; -ms-overflow-style: none;  } .no-scrollbars-s::-webkit-scrollbar { display: none; } }
+@media (min-width: 1024px) { .no-scrollbars-m { scrollbar-width: none; -ms-overflow-style: none;  } .no-scrollbars-m::-webkit-scrollbar { display: none; } }
+@media (min-width: 1599px) { .no-scrollbars-l { scrollbar-width: none; -ms-overflow-style: none;  } .no-scrollbars-l::-webkit-scrollbar { display: none; } }
 
 .scroll-snap {
     --scrollDirection: x;


### PR DESCRIPTION
Hey,
so the following issue occurred to me:

```
SassError: property "-moz-scrollbars-none" must be followed by a ':'
        on line 457 of node_modules/selekkt-skelet/css/skelet.css
        from line 2 of /Users/david/Projekte/dump/app/assets/stylesheets/application.scss
>> ar-width: none; -ms-overflow-style: none; -moz-scrollbars-none; } .no-scroll
   ------------------------------------------^
```
simply removing the `-moz-scrollbars-none;` property solved this issue. I don't know if there is a better alternative to this problem other than outright removing the property (maybe `-moz-scrollbars-none:;`). See this pull request more like an issue :)

Anyway thank you for your great work, I will build my next smaller project with skelet!