### PR TITLE
[docs] Fix minor closing tag typo in docs

### DIFF
--- a/docs/flexbox.html
+++ b/docs/flexbox.html
@@ -21,9 +21,9 @@
         <p>To create a Flexbox, you need a <code>&lt;x-flex&gt;</code> container</p>
     </x-col>
     <x-col span="6.." class="large-only"><pre><code>&lt;x-flex direction=row wrap=nowrap&gt;
-    &lt;x-col&gt;Skelet.&lt;/c&gt;
-    &lt;x-col&gt;by&lt;/c&gt;
-    &lt;x-col&gt;Sēlekkt.&lt;/c&gt;
+    &lt;x-col&gt;Skelet.&lt;/x-col&gt;
+    &lt;x-col&gt;by&lt;/x-col&gt;
+    &lt;x-col&gt;Sēlekkt.&lt;/x-col&gt;
 &lt;/x-flex&gt;</code></pre></x-col>
 
     <x-col span="row"><hr></x-col>

--- a/docs/grids.html
+++ b/docs/grids.html
@@ -6,9 +6,9 @@
 
     <x-col span="4.." span-s="row">
         <pre><code>&lt;x-grid columns=8&gt;
-  &lt;x-col span=3&gt;Skelet&lt;/c&gt;
-  &lt;x-col span=7-8&gt;by&lt;/c&gt;
-  &lt;x-col span=2+2&gt;Sēlekkt.&lt;/c&gt;
+  &lt;x-col span=3&gt;Skelet&lt;/x-col&gt;
+  &lt;x-col span=7-8&gt;by&lt;/x-col&gt;
+  &lt;x-col span=2+2&gt;Sēlekkt.&lt;/x-col&gt;
 &lt;/x-grid&gt;</code></pre>
     </x-col>
 


### PR DESCRIPTION
I recently discovered Skelet and found a typo in the docs while prototyping. In the sample code for flexbox and grids, the closing tag for `<x-col>` was `</c>` instead of `</x-col>`.

Excuse my inexperience, I'm new to collaborating using git, and was not sure if such minor details are mentioned via issues. I also noticed that the docs haven't been updated for about a year, so I was unsure whether it would be better to update the docs with an all-in-one pull request that fixes other things too.